### PR TITLE
Improve CMS 5 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     }
   ],
   "require": {
-    "silverstripe/vendor-plugin": "^1.0",
     "silverstripe/cms": "^4.0 | ^5.0"
   },
   "suggest": {


### PR DESCRIPTION
Some modules in CMS 5 compatibliity require vendor-plugin ^2, creating an unresolvable conflict of requirements. vendor-plugin is required by Silverstripe CMS and can be consiered an integral part of that dependency (i.e. part of a whole), so an individual direct dependency to it is unwarranted anyway.